### PR TITLE
Display related pages on domain, task, role pages

### DIFF
--- a/_includes/item_details.html
+++ b/_includes/item_details.html
@@ -1,2 +1,6 @@
 <h1>{{ page.title }}</h1>
 {{ page.description }}
+
+{% if page.edam_url %}
+See also: [{{ page.title }} in EDAM]({{ page.edam_url }}).
+{% endif %}

--- a/_includes/related_pages.html
+++ b/_includes/related_pages.html
@@ -1,0 +1,17 @@
+<h2>Related pages</h2>
+
+{%- for section in page.related_pages %}
+      
+<h3> {{ section[0] | replace: "_", " " | capitalize }} </h3>
+
+<ul>
+  {%- for page_id in section[1] %}
+    {%- assign section_pages = site.pages | where:"type", section[0] %}
+    {%- assign metadata = section_pages | where:"page_id", page_id %}
+    {%- for page_hit in metadata %}
+    <li><a href="{{ page_hit.url | relative_url }}">{{page_hit.title }}</a></li>
+    {%- endfor %}
+  {%- endfor %}
+</ul>
+  
+{%- endfor %}

--- a/_includes/related_pages.html
+++ b/_includes/related_pages.html
@@ -1,3 +1,4 @@
+{%- if page.related_pages %}
 <h2>Related pages</h2>
 
 {%- for section in page.related_pages %}
@@ -15,3 +16,4 @@
 </ul>
   
 {%- endfor %}
+{% endif %}

--- a/pages/domains/biomedical_science.md
+++ b/pages/domains/biomedical_science.md
@@ -1,10 +1,14 @@
 ---
 title: Biomedical Science
-description: Topic concerning biological science that is (typically) performed in the context of medicine. [See also](http://edamontology.org/topic_3344)
+description: Topic concerning biological science that is (typically) performed in the context of medicine. 
 icon: fa-flask-vial
 page_id: biomedical_science
+edam_url: http://edamontology.org/topic_3344
 related_pages: 
   tasks: [compliance, curation, conduct_research]
   roles: [data_analyst, researcher]
+  
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/domains/chemistry.md
+++ b/pages/domains/chemistry.md
@@ -1,10 +1,13 @@
 ---
 title: Chemistry
-description: The composition and properties of matter, reactions, and the use of reactions to create new substances. [See also](http://edamontology.org/topic_3314)
+description: The composition and properties of matter, reactions, and the use of reactions to create new substances.
 icon: fa-flask-vial
 page_id: chemistry
+edam_url: http://edamontology.org/topic_3314
 related_pages: 
   tasks: [compliance, manage_data, conduct_research]
   roles: [compliance_officer, data_analyst, researcher]
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/domains/informatics.md
+++ b/pages/domains/informatics.md
@@ -1,10 +1,13 @@
 ---
 title: Informatics
-description: The study and practice of information processing and use of computer information systems. [See also](http://edamontology.org/topic_0605)
+description: The study and practice of information processing and use of computer information systems.
 icon: fa-lightblub
 page_id: informatics
+edam_url: http://edamontology.org/topic_0605
 related_pages: 
   tasks: [data_handling, manage_data, software_development]
   roles: [compliance_officer, data_analyst, software_developer]
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/domains/language_text.md
+++ b/pages/domains/language_text.md
@@ -1,10 +1,13 @@
 ---
 title: Language and Text Analytics
-description: The scientific literature, language processing, reference information, and documentation. [See also](http://edamontology.org/topic_3068)
+description: The scientific literature, language processing, reference information, and documentation.
 icon: fa-book
 page_id: language_text
+edam_url: http://edamontology.org/topic_3068
 related_pages: 
   tasks: [curation, data_handling, manage_data, software_development]
   roles: [data_analyst, researcher, software_developer]
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/domains/medicine.md
+++ b/pages/domains/medicine.md
@@ -1,10 +1,13 @@
 ---
 title: Medicine
-description: Research in support of healing by diagnosis, treatment, and prevention of disease. [See also](http://edamontology.org/topic_3303)
+description: Research in support of healing by diagnosis, treatment, and prevention of disease.
 icon: fa-stethoscope
 page_id: medicine
+edam_url: http://edamontology.org/topic_3303
 related_pages: 
   tasks: [conduct_research]
   roles: [researcher]
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/domains/omics.md
+++ b/pages/domains/omics.md
@@ -1,10 +1,13 @@
 ---
 title: Omics
-description: The collective characterisation and quantification of pools of biological molecules that translate into the structure, function, and dynamics of an organism or organisms.  [See also](http://edamontology.org/topic_3391)
+description: The collective characterisation and quantification of pools of biological molecules that translate into the structure, function, and dynamics of an organism or organisms.
 icon: fa-dna
 page_id: omics
+edam_url: http://edamontology.org/topic_3391
 related_pages: 
   tasks: [data_handling, manage_data, conduct_research]
   roles: [data_analyst, researcher]
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/compliance_officer.md
+++ b/pages/roles/compliance_officer.md
@@ -5,3 +5,5 @@ icon: fa-list-check
 page_id: compliance_officer
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/data_analyst.md
+++ b/pages/roles/data_analyst.md
@@ -7,3 +7,5 @@ related_pages:
   domains: [biomedical_science]
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/data_steward.md
+++ b/pages/roles/data_steward.md
@@ -5,3 +5,5 @@ icon: fa-file-shield
 page_id: data_steward
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/information_architect.md
+++ b/pages/roles/information_architect.md
@@ -5,3 +5,5 @@ icon: fa-file-contract
 page_id: information_architect
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/managerial.md
+++ b/pages/roles/managerial.md
@@ -5,3 +5,5 @@ icon: fa-paperclip
 page_id: managerial
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/repository_manager.md
+++ b/pages/roles/repository_manager.md
@@ -5,3 +5,5 @@ icon: fa-database
 page_id: repository_manager
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/researcher.md
+++ b/pages/roles/researcher.md
@@ -5,3 +5,5 @@ icon: fa-microscope
 page_id: researcher
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/roles/software_developer.md
+++ b/pages/roles/software_developer.md
@@ -5,3 +5,5 @@ icon: fa-code
 page_id: software_developer
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/tasks/compliance.md
+++ b/pages/tasks/compliance.md
@@ -5,3 +5,5 @@ icon: fa-list-check
 page_id: compliance
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/tasks/conduct_research.md
+++ b/pages/tasks/conduct_research.md
@@ -5,3 +5,5 @@ icon: fa-microscope
 page_id: conduct_research
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/tasks/curation.md
+++ b/pages/tasks/curation.md
@@ -5,3 +5,5 @@ icon: fa-file-circle-check
 page_id: curation
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/tasks/data_handling.md
+++ b/pages/tasks/data_handling.md
@@ -5,3 +5,5 @@ icon: fa-laptop-file
 page_id: data_handling
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/tasks/manage_data.md
+++ b/pages/tasks/manage_data.md
@@ -5,3 +5,5 @@ icon: fa-database
 page_id: manage_data
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}

--- a/pages/tasks/software_development.md
+++ b/pages/tasks/software_development.md
@@ -5,3 +5,5 @@ icon: fa-code
 page_id: software_development
 ---
 {% include item_details.html %}
+
+{% include related_pages.html %}


### PR DESCRIPTION
Makes related pages visible on the individual pages for domains, tasks and roles.

Also moves the EDAM links for domains to a more readable location.

Progress on #36 