### PR TITLE
Pull recent updates

### DIFF
--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -46,3 +46,6 @@
 
 - question: "How is RO-Crate different from other data packaging formats?"
   answer: "RO-Crate is unique in its use of [schema.org](https://schema.org) annotations, which allow for rich metadata descriptions of the data, making it more discoverable and reusable. It also provides a lightweight and flexible approach, making it easier for researchers to adopt and use."
+
+- question: "How can I cite RO-Crate?"
+  answer: "See [Cite RO-Crate](about_ro_crate#cite-ro-crate)."

--- a/_specification/1.1/appendix/changelog.md
+++ b/_specification/1.1/appendix/changelog.md
@@ -28,7 +28,7 @@ excerpt: List of changes in releases of this specifications
 * [RO-Crate 1.1.3](https://github.com/ResearchObject/ro-crate/releases/tag/1.1.3) 
   * JSON-LD context https://w3id.org/ro/crate/1.1/context fix typo in mapping from `RepositoryObject` to <http://pcdm.org/2016/04/18/models#Object> [#243](https://github.com/ResearchObject/ro-crate/issues/243)
 * [RO-Crate 1.1.2](https://github.com/ResearchObject/ro-crate/releases/tag/1.1.2) 
-  * Typo fixes in [data entity section](../data-entities) [#177](https://github.com/ResearchObject/ro-crate/issues/177), [workflow section](../workflows)180](https://github.com/ResearchObject/ro-crate/issues/180), [metadata section](../metadata)](https://github.com/ResearchObject/ro-crate/issues/181) and others.
+  * Typo fixes in [data entity section](../data-entities) [#177](https://github.com/ResearchObject/ro-crate/issues/177), [workflow section](../workflows) [#180](https://github.com/ResearchObject/ro-crate/issues/180), [metadata section](../metadata) [#181](https://github.com/ResearchObject/ro-crate/issues/181) and others.
   * Correct namespace for `rdfs:comment` on [ad-hoc terms](jsonld#add-local-definitions-of-ad-hoc-terms) [#164](https://github.com/ResearchObject/ro-crate/issues/164)
   * Fixed broken links to Bioschemas and SPAR ontologies [#185](https://github.com/ResearchObject/ro-crate/issues/185) (note: `conformsTo` URIs unchanged, will be updated in RO-Crate 1.2)
 * [RO-Crate 1.1.1](https://github.com/ResearchObject/ro-crate/releases/tag/1.1.1)

--- a/_specification/1.2-DRAFT/root-data-entity.md
+++ b/_specification/1.2-DRAFT/root-data-entity.md
@@ -1,5 +1,7 @@
 ---
 title: Root Data Entity
+redirect_from:
+  - /1.2-DRAFT/root-data-entity
 nav_order: 5
 parent: RO-Crate 1.2-DRAFT 
 ---

--- a/_specification/1.2-DRAFT/structure.md
+++ b/_specification/1.2-DRAFT/structure.md
@@ -1,5 +1,7 @@
 ---
 title: RO-Crate Structure
+redirect_from:
+  - /1.2-DRAFT/structure
 nav_order: 3
 parent: RO-Crate 1.2-DRAFT
 ---

--- a/_specification/1.2-DRAFT/terminology.md
+++ b/_specification/1.2-DRAFT/terminology.md
@@ -1,5 +1,7 @@
 ---
 title: Terminology
+redirect_from:
+  - /1.2-DRAFT/terminology
 nav_order: 2
 parent: RO-Crate 1.2-DRAFT
 ---

--- a/pages/about/about_ro_crate.md
+++ b/pages/about/about_ro_crate.md
@@ -103,6 +103,29 @@ The [RO-Crate specification](specification) is developed openly on GitHub by res
 
 Anyone can join the RO-Crate community and contribute to these outputs. See the [Community](community) pages for more information.
 
+## Cite RO-Crate
+
+### Cite RO-Crate as project/approach
+
+Stian Soiland-Reyes, Peter Sefton, Mercè Crosas, Leyla Jael Castro, Frederik Coppens, José M. Fernández, Daniel Garijo, Björn Grüning, Marco La Rosa, Simone Leo, Eoghan Ó Carragáin, Marc Portier, Ana Trisovic, RO-Crate Community, Paul Groth, Carole Goble (2022):  
+**Packaging research artefacts with RO-Crate**.  
+_Data Science_ **5**(2)  
+<https://doi.org/10.3233/DS-210053>  
+
+### Cite RO-Crate Specification (any version)
+
+Peter Sefton, Eoghan Ó Carragáin, Stian Soiland-Reyes, Oscar Corcho, Daniel Garijo, Raul Palma, Frederik Coppens, Carole Goble, José María Fernández, Kyle Chard, Jose Manuel Gomez-Perez, Michael R Crusoe, Ignacio Eguinoa, Nick Juty, Kristi Holmes, Jason A. Clark, Salvador Capella-Gutierrez, Alasdair J. G. Gray, Stuart Owen, Alan R Williams, Giacomo Tartari, Finn Bacall, Thomas Thelen, Hervé Ménager, Laura Rodríguez Navas, Paul Walk, brandon whitehead, Mark Wilkinson, Paul Groth, Erich Bremer, LJ Garcia Castro, Karl Sebby, Alexander Kanitz, Ana Trisovic, Gavin Kennedy, Mark Graves, Jasper Koehorst, Simone Leo, Marc Portier (2020):  
+**RO-Crate Metadata Specification**  
+_researchobject.org / Zenodo_  
+<https://doi.org/10.5281/zenodo.3406497> 
+
+For citing a particular [version of RO-Crate specification](specification) see its embedded _Cite this version_ DOI.
+
+### Other citations
+
+See also [recent publications, presentations and citations](outreach).
+
+
 ## More information
 
 Check the [FAQ](faq) for answers to common questions.

--- a/pages/community/community.md
+++ b/pages/community/community.md
@@ -105,6 +105,11 @@ The _RO-Crate_ team is:
 * Martin Weise <http://orcid.org/0000-0003-4216-302X>
 * Vartika Bisht <https://orcid.org/0000-0002-1880-0597>
 * Toshiyuki Nishiyama Hiraki <https://orcid.org/0000-0001-6712-6335>
+* Bram Ulrichts <https://orcid.org/0000-0002-5934-8998>
+* Michael Falk <https://orcid.org/0000-0001-9261-8390>
+* Eli Chadwick <https://orcid.org/0000-0002-0035-6475>
+* Daniel Bauer <https://orcid.org/0000-0001-9447-460X>
+* James Love <https://github.com/JLoveUOA>
 
 The RO-Crate Community is open for anyone to [join us](https://github.com/ResearchObject/ro-crate/issues/1)!
 

--- a/pages/community/outreach.md
+++ b/pages/community/outreach.md
@@ -21,12 +21,6 @@ title: Outreach and Publications
 # RO-Crate Outreach and Publications 
 {: .no_toc }
 
-{: .tip}
-> **Upcoming tutorial**: _Improving FAIRability of your research outcomes with RO-Crates, SignPosting and Bioschemas_  
-> At [Semantic Web Applications and Tools for Health Care and Life Sciences](https://www.swat4ls.org/workshops/leiden2024/) (SWAT4HCLS), 2024-02-26/--29, Leiden, The Netherlands.  
-> [[Register](https://www.swat4ls.org/workshops/leiden2024/registration/) (by 12 February 2024)
-
-
 ## Table of contents
 {: .no_toc .text-delta }
 

--- a/pages/resources/examples.md
+++ b/pages/resources/examples.md
@@ -30,7 +30,7 @@ title: Examples
 The [RO-Crate structure](specification/1.1/structure) is that a _RO-Crate root_ directory has a _RO-Crate Metadata File_ named `ro-crate-metadata.json` that describe the other files, directories and URLs; as well as relating them to things in the world (e.g. people, instruments).
 
 {: .note }
-> From RO-Crate /specification/1.1 `ro-crate-metadata.jsonld` was renamed `ro-crate-metadata.json`.
+> From RO-Crate 1.1 `ro-crate-metadata.jsonld` was renamed `ro-crate-metadata.json`.
 
 The [specification](specification) has several inline examples:
  * [Skeleton ro-crate-metadata.json](specification/1.1/root-data-entity#ro-crate-metadata-file-descriptor)
@@ -41,7 +41,7 @@ The [specification](specification) has several inline examples:
  * [Example with computational workflow](specification/1.1/workflows#complete-workflow-example)
  * [RO-Crate specification](specification/1.1/ro-crate-preview) ([ro-crate-metadata.jsonld](specification/1.1/ro-crate-metadata.jsonld)) – the specification itself and its publication
 
-The [RO-Crate /specification/1.1](specification/1.1/) specification is largely **explained by examples** by showing additional fragments:
+The [RO-Crate 1.1](specification/1.1/) specification is largely **explained by examples** by showing additional fragments:
  * [Data entities](specification/1.1/data-entities) (files, folders)
  * [Web resources](specification/1.1/data-entities#web-based-data-entities)
  * [Contextual entities](specification/1.1/contextual-entities) such as [people](specification/1.1/contextual-entities#people), [organizations](specification/1.1/contextual-entities#organizations-as-values), [citations](specification/1.1/contextual-entities#publications-via-citation-property), [licensing](specification/1.1/contextual-entities#licensing-access-control-and-copyright), [places](specification/1.1/contextual-entities#places)
@@ -71,7 +71,7 @@ Workflows can be exported from Workflow Hub as RO-Crates, e.g. [a Galaxy workflo
 
 ## Biocompute Object
 
-<https://github.com/biocompute-objects/bco-ro-example-chipseq> hosts an example RO-Crate ([ro-crate-metadata.json](https://rawcdn.githack.com/biocompute-objects/bco-ro-example-chipseq/76cb84c8d6a17a3fd7ae3102f68de3f780458601/data/ro-crate-metadata.json), [ro-crate-preview.html](https://rawcdn.githack.com/biocompute-objects/bco-ro-example-chipseq/76cb84c8d6a17a3fd7ae3102f68de3f780458601/data/ro-crate-preview.html)) that capture a [BioCompute Object](https://www.biocomputeobject.org/) (IEEE 2791) using [BagIt](https://www.researchobject.org/ro-crate//specification/1.1/appendix/implementation-notes.html#adding-ro-crate-to-bagit).  See the tutorial [Create an BCO RO-Crate](https://biocompute-objects.github.io/bco-ro-crate/tutorial/) for step-by-step details.
+<https://github.com/biocompute-objects/bco-ro-example-chipseq> hosts an example RO-Crate ([ro-crate-metadata.json](https://rawcdn.githack.com/biocompute-objects/bco-ro-example-chipseq/76cb84c8d6a17a3fd7ae3102f68de3f780458601/data/ro-crate-metadata.json), [ro-crate-preview.html](https://rawcdn.githack.com/biocompute-objects/bco-ro-example-chipseq/76cb84c8d6a17a3fd7ae3102f68de3f780458601/data/ro-crate-preview.html)) that capture a [BioCompute Object](https://www.biocomputeobject.org/) (IEEE 2791) using [BagIt](https://www.researchobject.org/ro-crate/specification/1.1/appendix/implementation-notes.html#adding-ro-crate-to-bagit).  See the tutorial [Create an BCO RO-Crate](https://biocompute-objects.github.io/bco-ro-crate/tutorial/) for step-by-step details.
 
 ## ACTION: Survey Ontology
 

--- a/pages/resources/profiles.md
+++ b/pages/resources/profiles.md
@@ -135,7 +135,7 @@ additional terms from the
 
 ```json
 [
-    "https://w3id.org/ro/crate/specification/1.1/context",
+    "https://w3id.org/ro/crate/1.1/context",
     {
         "TestSuite": "https://w3id.org/ro/terms/test#TestSuite",
         "TestInstance": "https://w3id.org/ro/terms/test#TestInstance",


### PR DESCRIPTION
Some small fixes while I work on migrating this website to the other repo.

Also one point of confusion: the use case text for Arkisto, WfExS, and WorkflowHub seems to have changed, but I can't figure out when or where this happened (can't find it in the commit history). @a-mile @nsjuty or @stain which version should be used?

Arkisto: [original](https://www.researchobject.org/ro-crate/in-use/arkisto.html) [new](https://www.researchobject.org/ro-crate-2024/arkisto)
WfExS: [original](https://www.researchobject.org/ro-crate/in-use/wfexs.html) [new](https://www.researchobject.org/ro-crate-2024/wfexs)
[edited to add] WorkflowHub [original](https://www.researchobject.org/ro-crate/in-use/workflowhub.html) [new](https://www.researchobject.org/ro-crate-2024/workflow-hub)